### PR TITLE
Added support for IP hostable server

### DIFF
--- a/v1_flask/main.py
+++ b/v1_flask/main.py
@@ -77,4 +77,5 @@ def toggleFinished():
     return jsonify({"success": True})
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    # app.run(debug=True)
+    app.run(host='0.0.0.0')


### PR DESCRIPTION
The server would now be hosted on machine's local IP rather than localhost. Also since this employs a deployed version of the app, it need not be run in debug mode